### PR TITLE
Add Discord CTAs and add Tikeape to team

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -28,6 +28,18 @@ export default function AboutPage() {
             We distill frontier reasoning models into much smaller open models and publish the datasets to
             help the community train, evaluate, and deploy locally.
           </p>
+          <p className="mt-3 max-w-2xl text-sm text-muted-foreground md:text-base">
+            Join our Discord community for updates and collaboration.
+            {" "}
+            <a
+              href="https://discord.com/invite/zSsFYQBdYR"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              Join Discord
+            </a>
+          </p>
         </div>
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,6 +86,11 @@ export default async function Home() {
               <Button asChild size="lg" variant="secondary">
                 <Link href="/datasets">View Datasets</Link>
               </Button>
+              <Button asChild variant="outline" className="border-border/60 text-muted-foreground hover:text-foreground">
+                <a href="https://discord.com/invite/zSsFYQBdYR" target="_blank" rel="noopener noreferrer">
+                  Join Discord
+                </a>
+              </Button>
             </div>
           </div>
         </div>
@@ -250,11 +255,18 @@ export default async function Home() {
                 costs add up quickly - our Claude Opus dataset alone cost $52+ to create.
                 If you find our models useful, consider supporting us.
                 </p>
-                <Button asChild size="lg" className="shadow-sm">
-                  <a href="https://paypal.me/TeichAI" target="_blank" rel="noopener noreferrer">
-                    Donate via PayPal
-                  </a>
-                </Button>
+                <div className="flex flex-wrap gap-3">
+                  <Button asChild size="lg" className="shadow-sm">
+                    <a href="https://paypal.me/TeichAI" target="_blank" rel="noopener noreferrer">
+                      Donate via PayPal
+                    </a>
+                  </Button>
+                  <Button asChild size="lg" variant="secondary">
+                    <a href="https://discord.com/invite/zSsFYQBdYR" target="_blank" rel="noopener noreferrer">
+                      Join Discord
+                    </a>
+                  </Button>
+                </div>
               </div>
             </CardContent>
           </Card>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -332,4 +332,10 @@ export const team = [
     focus: "Research & development",
     link: "https://huggingface.co/owenqwenllmwine",
   },
+  {
+    name: "Tikeape",
+    role: "Member",
+    focus: "Team member",
+    link: "https://huggingface.co/tikeape",
+  },
 ];


### PR DESCRIPTION
Added a “Join Discord” button next to “View Datasets,” in the “Support Our Work” section at the bottom, and in the “About” summary. Additionally, added Tikeape (myself) to the team members list as a team member.